### PR TITLE
escaping html in description of rss feed

### DIFF
--- a/src/cloudscribe.SimpleContent.Syndication/RssChannelProvider.cs
+++ b/src/cloudscribe.SimpleContent.Syndication/RssChannelProvider.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
 using cloudscribe.SimpleContent.Models;
@@ -142,18 +143,18 @@ namespace cloudscribe.SimpleContent.Syndication
                     }
                 }
 
-                
+
                 //rssItem.Comments
-                if(project.UseMetaDescriptionInFeed)
+                if (project.UseMetaDescriptionInFeed)
                 {
-                    rssItem.Description = post.MetaDescription;
+                    rssItem.Description = HtmlEncoder.Default.Encode(post.MetaDescription);
                 }
                 else
                 {
                     // change relative urls in content to absolute
-                    rssItem.Description = htmlProcessor.ConvertUrlsToAbsolute(baseUrl, post.Content);
+                    rssItem.Description = HtmlEncoder.Default.Encode(htmlProcessor.ConvertUrlsToAbsolute(baseUrl, post.Content));
                 }
-                
+
                 //rssItem.Enclosures
                 rssItem.Guid = new RssGuid(post.Id);
                 string postUrl;


### PR DESCRIPTION
After getting the latest code as mentioned in https://github.com/joeaudette/cloudscribe.SimpleContent/issues/7 a rss feed is generated but I noticed that the generated feed data is not valid according to [W3C Feed Validation Service, for Atom and RSS](https://validator.w3.org/feed/).