### PR TITLE
fix 404 for /csscsr/* requests including pagetree.js

### DIFF
--- a/src/cloudscribe.SimpleContent.Web/Controllers/csscsrController.cs
+++ b/src/cloudscribe.SimpleContent.Web/Controllers/csscsrController.cs
@@ -55,7 +55,7 @@ namespace cloudscribe.SimpleContent.Web.Mvc.Controllers
         [AllowAnonymous]
         public IActionResult js()
         {
-            var baseSegment = "cloudscribe.SimpleContent.Web.Mvc.js.";
+            var baseSegment = "cloudscribe.SimpleContent.Web.js.";
             
             var requestPath = HttpContext.Request.Path.Value;
             log.LogDebug(requestPath + " requested");
@@ -74,7 +74,7 @@ namespace cloudscribe.SimpleContent.Web.Mvc.Controllers
         [AllowAnonymous]
         public IActionResult css()
         {
-            var baseSegment = "cloudscribe.SimpleContent.Web.Mvc.css.";
+            var baseSegment = "cloudscribe.SimpleContent.Web.css.";
             
             var requestPath = HttpContext.Request.Path.Value;
             log.LogDebug(requestPath + " requested");

--- a/test/cloudscribe.SimpleContent.Web.Tests/Web/csscsrControllerShould.cs
+++ b/test/cloudscribe.SimpleContent.Web.Tests/Web/csscsrControllerShould.cs
@@ -1,0 +1,56 @@
+﻿using cloudscribe.SimpleContent.Web.Mvc.Controllers;
+using cloudscribe.Web.Common.Helpers;
+using Castle.Core.Logging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace cloudscribe.SimpleContent.Web.Web
+{
+    public class csscsrControllerShould
+    {
+
+        [Fact]
+        public void Return_Expected_Stream_For_PageTree_js()
+        {
+
+            var controllerLoggerMock = new Mock<ILogger<csscsrController>>();
+            var resourceHelperMock = new ResourceHelper(new Mock<ILogger<ResourceHelper>>().Object);
+
+
+            var csscsrController = new csscsrController(resourceHelperMock, controllerLoggerMock.Object);
+
+            csscsrController.ControllerContext = new ControllerContext();
+            csscsrController.ControllerContext.HttpContext = new DefaultHttpContext();
+            csscsrController.ControllerContext.HttpContext.Request.Path = "/csscsr/js/pagetree.js";
+
+            var result = csscsrController.js();
+
+            Assert.IsAssignableFrom<FileStreamResult>(result);
+        }
+
+        [Fact]
+        public void Return_Expected_Stream_For_BlogCommon_css()
+        {
+
+            var controllerLoggerMock = new Mock<ILogger<csscsrController>>();
+            var resourceHelperMock = new ResourceHelper(new Mock<ILogger<ResourceHelper>>().Object);
+
+
+            var csscsrController = new csscsrController(resourceHelperMock, controllerLoggerMock.Object);
+
+            csscsrController.ControllerContext = new ControllerContext();
+            csscsrController.ControllerContext.HttpContext = new DefaultHttpContext();
+            csscsrController.ControllerContext.HttpContext.Request.Path = "/csscsr/css/blog-common.css";
+
+            var result = csscsrController.css();
+
+            Assert.IsAssignableFrom<FileStreamResult>(result);
+            
+        }
+
+    }
+}

--- a/test/cloudscribe.SimpleContent.Web.Tests/cloudscribe.SimpleContent.Web.Tests.csproj
+++ b/test/cloudscribe.SimpleContent.Web.Tests/cloudscribe.SimpleContent.Web.Tests.csproj
@@ -21,4 +21,8 @@
     <ProjectReference Include="..\..\src\cloudscribe.SimpleContent.Web\cloudscribe.SimpleContent.Web.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Web\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixed csscsr controller not found errors after move of cloudscribe.SimpleContent.Web.MVC project into main cloudscribe.SimpleContent.Web project;
Added test coverage;
#247 